### PR TITLE
Fix cuda terminate

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,68 +1,67 @@
 name: Build
 on:
-  push:
-    tags:
-      - '*'
+  pull_request:
+    branches: [ master ]
 jobs:
-  wheel-build:
-    name: Build qiskit-aer wheels
-    strategy:
-      matrix:
-        os: ["macOS-latest", "ubuntu-latest"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.7'
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel==1.5.5
-      - name: Build wheels
-        env:
-          CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
-          CIBW_BEFORE_BUILD: "pip install -U Cython pip virtualenv pybind11"
-          CIBW_SKIP: "cp27-* cp34-* cp35-* pp*"
-          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2010"
-          CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
-          CIBW_TEST_COMMAND: "python3 {project}/tools/verify_wheels.py"
-          CIBW_TEST_REQUIRES: "git+https://github.com/Qiskit/qiskit-terra.git"
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
-      - name: Publish Wheels
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: qiskit
-        run : |
-          pip install -U twine
-          twine upload wheelhouse/*
-  sdist:
-    name: Publish qiskit-aer sdist
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.8'
-      - name: Install Deps
-        run: pip install -U twine wheel
-      - name: Build Artifacts
-        run: |
-          python setup.py sdist
-        shell: bash
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./dist/qiskit*
-      - name: Publish to PyPi
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: qiskit
-        run: twine upload dist/qiskit*
+#  wheel-build:
+#    name: Build qiskit-aer wheels
+#    strategy:
+#      matrix:
+#        os: ["macOS-latest", "ubuntu-latest"]
+#    runs-on: ${{ matrix.os }}
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions/setup-python@v2
+#        name: Install Python
+#        with:
+#          python-version: '3.7'
+#      - name: Install cibuildwheel
+#        run: |
+#          python -m pip install cibuildwheel==1.5.5
+#      - name: Build wheels
+#        env:
+#          CIBW_BEFORE_ALL_LINUX: "yum install -y openblas-devel"
+#          CIBW_BEFORE_BUILD: "pip install -U Cython pip virtualenv pybind11"
+#          CIBW_SKIP: "cp27-* cp34-* cp35-* pp*"
+#          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2010"
+#          CIBW_MANYLINUX_I686_IMAGE: "manylinux2010"
+#          CIBW_TEST_COMMAND: "python3 {project}/tools/verify_wheels.py"
+#          CIBW_TEST_REQUIRES: "git+https://github.com/Qiskit/qiskit-terra.git"
+#        run: |
+#          python -m cibuildwheel --output-dir wheelhouse
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          path: ./wheelhouse/*.whl
+#      - name: Publish Wheels
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: qiskit
+#        run : |
+#          pip install -U twine
+#          twine upload wheelhouse/*
+#  sdist:
+#    name: Publish qiskit-aer sdist
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions/setup-python@v2
+#        name: Install Python
+#        with:
+#          python-version: '3.8'
+#      - name: Install Deps
+#        run: pip install -U twine wheel
+#      - name: Build Artifacts
+#        run: |
+#          python setup.py sdist
+#        shell: bash
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          path: ./dist/qiskit*
+#      - name: Publish to PyPi
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: qiskit
+#        run: twine upload dist/qiskit*
   gpu-build:
     name: Build qiskit-aer-gpu wheels
     runs-on: ubuntu-latest
@@ -90,10 +89,10 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Publish Wheels
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: qiskit
-        run : |
-          pip install -U twine
-          twine upload wheelhouse/*
+#      - name: Publish Wheels
+#        env:
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          TWINE_USERNAME: qiskit
+#        run : |
+#          pip install -U twine
+#          twine upload wheelhouse/*

--- a/src/simulators/statevector/qubitvector_thrust.hpp
+++ b/src/simulators/statevector/qubitvector_thrust.hpp
@@ -1680,7 +1680,7 @@ void QubitVectorThrust<data_t>::set_num_qubits(size_t num_qubits)
   tid = omp_get_thread_num();
   m_nDev = 1;
 #ifdef AER_THRUST_CUDA
-  cudaGetDeviceCount(&m_nDev);
+  if(cudaGetDeviceCount(&m_nDev) != cudaSuccess) throw std::runtime_error("No CUDA device available");
 #endif
 
   m_iDev = 0;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Added an exception when no CUDA device are found to avoid call to terminate when running verify_wheels. py on CI.
Temporarily enable CI GPU wheel build to test verify_wheel (.github/workflows/wheels.yml file must be reverted before final merge)

### Details and comments


